### PR TITLE
feat: support querying per resource limits

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,12 @@
 use reqwest::header::USER_AGENT;
+use std::collections::HashMap;
 use std::env;
+use std::error::Error;
 use std::time::Duration;
 use tokio::time::sleep;
 
 #[tokio::main]
-async fn main() -> Result<(), reqwest::Error> {
+async fn main() -> Result<(), Box<dyn Error>> {
     let mut req = reqwest::Client::new().get("https://api.github.com/rate_limit");
     let token = env::var("GITHUB_TOKEN")
         .or(env::var("GITHUB_API_TOKEN"))
@@ -16,26 +18,30 @@ async fn main() -> Result<(), reqwest::Error> {
     }
     let resp = req.send().await?;
     resp.error_for_status_ref()?;
-    let rate_limit = resp.json::<RateLimitResponse>().await?.rate;
+
+    let resource = env::args().skip(1).find(|arg| !arg.starts_with('-')).unwrap_or(String::from("core"));
+    let resources = resp.json::<RateLimitResponse>().await?.resources;
+    let rate_limit = resources.get(&resource).ok_or_else(|| format!("GitHub rate limit resource '{resource}' not found"))?;
+
     let reset_time = chrono::DateTime::from_timestamp(rate_limit.reset as i64, 0)
         .unwrap()
         .naive_local();
     let duration = Duration::from_secs(rate_limit.reset - chrono::Utc::now().timestamp() as u64);
     let rel_time = humantime::format_duration(duration);
     if rate_limit.remaining == 0 {
-        eprintln!("Rate limit exceeded, sleeping for {rel_time} until {reset_time}",);
+        eprintln!("GitHub {resource} rate limit exceeded, sleeping for {rel_time} until {reset_time}");
         sleep(duration).await;
     } else if env::args().all(|arg| arg != "--quiet" && arg != "-q") {
         let remaining = rate_limit.remaining;
         let limit = rate_limit.limit;
-        println!("GitHub rate limit: {remaining}/{limit} - resets at {reset_time} (~{rel_time})");
+        println!("GitHub {resource} rate limit: {remaining}/{limit} - resets at {reset_time} (~{rel_time})");
     }
     Ok(())
 }
 
 #[derive(Debug, serde::Deserialize)]
 struct RateLimitResponse {
-    rate: RateLimit,
+    resources: HashMap<String, RateLimit>
 }
 
 #[derive(Debug, serde::Deserialize)]


### PR DESCRIPTION
While at it, switch from the top level rate to the core resource for the default case, as the former is closing down.

https://docs.github.com/en/rest/rate-limit/rate-limit?apiVersion=2022-11-28#get-rate-limit-status-for-the-authenticated-user
> The rate object is closing down. If you're writing new API client code or updating existing code, you should use the core object instead of the rate object. The core object contains the same information that is present in the rate object.

Closes https://github.com/jdx/wait-for-gh-rate-limit/issues/3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables selecting a specific GitHub rate limit resource and defaults to `core`.
> 
> - Parse first non-flag CLI arg as `resource` (default `core`); look up in API `resources` map
> - Replace `RateLimitResponse.rate` with `resources: HashMap<String, RateLimit>` and adjust deserialization
> - Update logs to include the selected resource and report its limits; sleep behavior applies per resource
> - Broaden `main` return type to `Result<(), Box<dyn Error>>`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7853d9d588bbee25e22f6078e0d3dc06bd46e6e6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->