### PR TITLE
fix: sleep an extra second past reset time

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let reset_time = chrono::DateTime::from_timestamp(rate_limit.reset as i64, 0)
         .unwrap()
         .naive_local();
-    let duration = Duration::from_secs(rate_limit.reset - chrono::Utc::now().timestamp() as u64);
+    let duration = Duration::from_secs(
+        rate_limit.reset - chrono::Utc::now().timestamp() as u64
+        /* requests on the reset second might still hit the previous limit */ + 1,
+    );
     let rel_time = humantime::format_duration(duration);
     if rate_limit.remaining == 0 {
         eprintln!("GitHub {resource} rate limit exceeded, sleeping for {rel_time} until {reset_time}");


### PR DESCRIPTION
In practice, immediately firing a request after we return from sleep exactly to the reset second may end up hitting the previous period and fail.