### PR TITLE
fix: treat remaining==1 as exceeded

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .naive_local();
     let duration = Duration::from_secs(rate_limit.reset - chrono::Utc::now().timestamp() as u64);
     let rel_time = humantime::format_duration(duration);
-    if rate_limit.remaining == 0 {
+    // There are no docs on it as of 2026-01-07,
+    // but a request when remaining==1 would already be rejected due to exceeding the limit, at least for code_search,
+    // even though one would expect that to happen only at remaining==0.
+    if rate_limit.remaining <= 1 {
         eprintln!("GitHub {resource} rate limit exceeded, sleeping for {rel_time} until {reset_time}");
         sleep(duration).await;
     } else if env::args().all(|arg| arg != "--quiet" && arg != "-q") {


### PR DESCRIPTION
That's what happens at least with code_search at time of writing: the limit is 10 per minute, but the 10th request within a minute gets rejected due to exceeding the limit, even though after the 9th the rate limit endpoint shows remaining=1, ditto the response headers for the 9th request.

I've filed a GH bug via support about this. Reproducer bash script:
```bash
#!/bin/bash
set -euo pipefail

: ${GITHUB_TOKEN:?required variable}

cmd=(
    curl
    --silent
    --head
    --header "x-github-api-version: 2022-11-28"
    --header "Authorization: Bearer $GITHUB_TOKEN"
)

for i in {1..10}; do
    "${cmd[@]}" "https://api.github.com/search/code?q=foo" \
	| grep -iE "^(HTTP/|x-ratelimit)"
done
```