### PR TITLE
chore: set dev profile debug to 1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,6 @@ tokio = { version = "1", features = ["full"] }
 
 [package.metadata.release]
 pre-release-hook = ["git", "cliff", "-o", "CHANGELOG.md", "--tag", "{{version}}"]
+
+[profile.dev]
+debug = 1


### PR DESCRIPTION
## Summary

Reduces `target/` disk usage by setting `[profile.dev] debug = 1`, while keeping backtrace file:line info intact.

The default `debug = 2` writes full DWARF — including variable/type info that's only needed when stepping through code in a debugger (lldb/gdb). With `debug = 1`, panics, `RUST_BACKTRACE=1`, and error chains still resolve to file:line; only debugger variable inspection is reduced.

In practice this typically shrinks `target/` by a meaningful percentage, which adds up across worktrees.

## Test plan

- [ ] `cargo build` still succeeds
- [ ] CI is green

---
*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration-only change that affects local dev build debug info and artifact size, without altering runtime behavior.
> 
> **Overview**
> Reduces development build debug info by adding `[profile.dev] debug = 1` in `Cargo.toml`, aiming to shrink `target/` output while keeping basic file:line backtraces.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49333d53d195e9571d46ebca389923ca8e08a8c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->